### PR TITLE
Implement a subset of mathvariants

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mathml2latex",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Convert mathml to latex.",
   "author": "Mika",
   "license": "MIT",

--- a/src/mathml2latex.js
+++ b/src/mathml2latex.js
@@ -71,8 +71,8 @@ function formatMathVariant (node, it) {
   const substitutions = {
     "normal": "\\mathrm",
     "bold": "\\mathbf",
-    "italic": "\\mathnormal",
-    "bold-italic": "\\bm",
+    "italic": "\\mathrm",
+    "bold-italic": "\\boldsymbol",
     "double-struck": "\\mathbb",
     "script": "\\mathscr",
     "fraktur": "\\mathfrak",

--- a/src/mathml2latex.js
+++ b/src/mathml2latex.js
@@ -63,38 +63,60 @@ function parseLeaf(node) {
   return r;
 }
 
+// References:
+// - https://w3c.github.io/mathml-core/#the-mathvariant-attribute
+// - https://ftp.tu-chemnitz.de/pub/tex/info/symbols/comprehensive/symbols-a4.pdf#page=123
+function formatMathVariant (node, it) {
+  const mathVariant = NodeTool.getAttr(node, "mathvariant", "").toLowerCase()
+  const substitutions = {
+    "normal": "\\mathrm",
+    "bold": "\\mathbf",
+    "italic": "\\mathnormal",
+    "bold-italic": "\\bm",
+    "double-struck": "\\mathbb",
+    "script": "\\mathscr",
+    "fraktur": "\\mathfrak",
+    "sans-serif": "\\mathsf"
+  }
+  const substituted = substitutions[mathVariant]
+  const hasSubstitution = !!substituted
+
+  return hasSubstitution ? `${substituted}{${it}}` : it
+}
+
 // operator token, mathematical operators
 function parseOperator(node) {
   let it = NodeTool.getNodeText(node).trim();
   it = MathSymbol.parseOperator(it);
-  return escapeSpecialChars(it);
+  return formatMathVariant(node, escapeSpecialChars(it));
 }
 
 // Math identifier
 function parseElementMi(node){
   let it = NodeTool.getNodeText(node).trim();
   it = MathSymbol.parseIdentifier(it);
-  return escapeSpecialChars(it);
+  return formatMathVariant(node, escapeSpecialChars(it));
 }
 
 // Math Number
 function parseElementMn(node){
   let it = NodeTool.getNodeText(node).trim();
-  return escapeSpecialChars(it);
+  return formatMathVariant(node, escapeSpecialChars(it));
 }
 
 // Math String
 function parseElementMs(node){
   const content = NodeTool.getNodeText(node).trimRight();
   const it = escapeSpecialChars(content);
-  return ['"', it, '"'].join('');
+  return ['"', formatMathVariant(node, it), '"'].join('');
 }
 
 // Math Text
+
 function parseElementMtext(node){
   const content = NodeTool.getNodeText(node)
   const it = escapeSpecialChars(content);
-  return `\\text{${it}}`;
+  return `\\text{${formatMathVariant(node, it)}}`
 }
 
 // Math glyph (image)

--- a/test/test-base.js
+++ b/test/test-base.js
@@ -79,8 +79,27 @@ const names = [
 
 names.forEach(testOverlapFunName)
 
-
 test("mo-math-func-name(overlap), multiply names", convert({
   from: '<mo>sin</mo><mo>sinh</mo>',
   to: '\\sin \\sinh ',
 }));
+
+const mathVariantPairs = [
+  ["normal", "\\mathrm"],
+  ["bold", "\\mathbf"],
+  ["italic", "\\mathnormal"],
+  ["bold-italic", "\\bm"],
+  ["double-struck", "\\mathbb"],
+  ["script", "\\mathscr"],
+  ["fraktur", "\\mathfrak"],
+  ["sans-serif", "\\mathsf"],
+]
+
+function testMathVariant([variant, translated]) {
+  test(`mi-mathvariant: ${variant}`, convert({
+    from: `<mi mathvariant="${variant}">R</mi>`,
+    to: `${translated}{R}`
+  }));
+}
+
+mathVariantPairs.forEach(testMathVariant)


### PR DESCRIPTION
This pull request implements a subset of MathML's allowed `mathvariants`. They are implemented with maximum compatibility in mind, so anything that was converted by `mathml2latex` before continues to be converted as is.

The attribute is implemented for all elements that support it directly as per https://developer.mozilla.org/en-US/docs/Web/MathML/Element. `mstyle` is not handled, `mspace` neither (because the implementation at the moment always returns an empty string anyways).

Please note that some `mathvariants` are left unimplemented: https://w3c.github.io/mathml-core/#dfn-mathvariant. This is done to minimize unexpected outcomes. While you could convert bold-fraktur for example, this wouldn't be rendered correctly in some environments (e.g. Katex). An implementation independent of target-environment might require major changes to the library as far as I can tell.