### PR TITLE
Fix mtr, munder & mover conversion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "mathml2latex",
-  "version": "1.1.3",
+  "name": "@androettop/mathml2latex",
+  "version": "1.1.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "mathml2latex",
-      "version": "1.1.1",
+      "name": "@androettop/mathml2latex",
+      "version": "1.1.5",
       "license": "MIT",
       "dependencies": {
         "domino": "^2.1.6"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@androettop/mathml2latex",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@androettop/mathml2latex",
-      "version": "1.1.5",
+      "version": "1.1.6",
       "license": "MIT",
       "dependencies": {
         "domino": "^2.1.6"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@androettop/mathml2latex",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Convert mathml to latex.",
   "author": "Mika",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "mathml2latex",
+  "name": "@androettop/mathml2latex",
   "version": "1.1.3",
   "description": "Convert mathml to latex.",
   "author": "Mika",
@@ -9,13 +9,13 @@
     "mathml",
     "latex"
   ],
-  "homepage": "https://github.com/mika-cn/mathml2latex",
+  "homepage": "https://github.com/androettop/mathml2latex",
   "repository": {
     "type": "git",
-    "url": "https://github.com/mika-cn/mathml2latex.git"
+    "url": "https://github.com/androettop/mathml2latex.git"
   },
   "bugs": {
-    "url": "https://github.com/mika-cn/mathml2latex/issues"
+    "url": "https://github.com/androettop/mathml2latex/issues"
   },
   "main": "lib/mathml2latex.cjs.js",
   "module": "lib/mathml2latex.es.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@androettop/mathml2latex",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "description": "Convert mathml to latex.",
   "author": "Mika",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@androettop/mathml2latex",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "Convert mathml to latex.",
   "author": "Mika",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@androettop/mathml2latex",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "Convert mathml to latex.",
   "author": "Mika",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@androettop/mathml2latex",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "Convert mathml to latex.",
   "author": "Mika",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@androettop/mathml2latex",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Convert mathml to latex.",
   "author": "Mika",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@androettop/mathml2latex",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "description": "Convert mathml to latex.",
   "author": "Mika",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@androettop/mathml2latex",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "description": "Convert mathml to latex.",
   "author": "Mika",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@androettop/mathml2latex",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "description": "Convert mathml to latex.",
   "author": "Mika",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@androettop/mathml2latex",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "description": "Convert mathml to latex.",
   "author": "Mika",
   "license": "MIT",

--- a/src/brackets.js
+++ b/src/brackets.js
@@ -25,7 +25,7 @@ const Brackets = {
         break;
       case '‖': r = '\\left\\|';
         break;
-      case '{': r = '\\left\\lbrace';
+      case '{': r = '\\left\\lbrace ';
         break;
       case '⟨': r = '\\left\\langle ';
         break;
@@ -49,15 +49,15 @@ const Brackets = {
         break;
       case '‖': r = '\\right\\|';
         break;
-      case '}': r = '\\right\\rbrace';
+      case '}': r = '\\right\\rbrace ';
         break;
-      case '⟩': r = ' \\right\\rangle';
+      case '⟩': r = ' \\right\\rangle ';
         break;
-      case '⌋': r = ' \\right\\rfloor';
+      case '⌋': r = ' \\right\\rfloor ';
         break;
-      case '⌉': r = ' \\right\\rceil';
+      case '⌉': r = ' \\right\\rceil ';
         break;
-      case '⌝': r = ' \\right\\urcorner';
+      case '⌝': r = ' \\right\\urcorner ';
         break;
     }
     return (stretchy ? r : r.replace('\\right', ''));

--- a/src/brackets.js
+++ b/src/brackets.js
@@ -21,9 +21,9 @@ const Brackets = {
     switch(it){
       case '(':
       case '[':
-      case '|': r = `\\left${it}`;
+      case '|': r = `\\left${it} `;
         break;
-      case '‖': r = '\\left\\|';
+      case '‖': r = '\\left\\| ';
         break;
       case '{': r = '\\left\\lbrace ';
         break;
@@ -45,9 +45,9 @@ const Brackets = {
     switch(it){
       case ')':
       case ']':
-      case '|': r = `\\right${it}`;
+      case '|': r = `\\right${it} `;
         break;
-      case '‖': r = '\\right\\|';
+      case '‖': r = '\\right\\| ';
         break;
       case '}': r = '\\right\\rbrace ';
         break;

--- a/src/brackets.js
+++ b/src/brackets.js
@@ -20,10 +20,11 @@ const Brackets = {
     let r = '';
     switch(it){
       case '(':
-      case '[':
       case '|': r = `\\left${it}`;
         break;
       case '‖': r = '\\left\\|';
+        break;
+      case '[': r = '\\left\\lbrack';
         break;
       case '{': r = '\\left\\lbrace';
         break;
@@ -44,12 +45,13 @@ const Brackets = {
     let r = '';
     switch(it){
       case ')':
-      case ']':
       case '|': r = `\\right${it}`;
         break;
       case '‖': r = '\\right\\|';
         break;
       case '}': r = '\\right\\rbrace';
+        break;
+      case ']': r = '\\right\\rbrack';
         break;
       case '⟩': r = ' \\right\\rangle';
         break;

--- a/src/brackets.js
+++ b/src/brackets.js
@@ -20,11 +20,10 @@ const Brackets = {
     let r = '';
     switch(it){
       case '(':
+      case '[':
       case '|': r = `\\left${it}`;
         break;
       case '‖': r = '\\left\\|';
-        break;
-      case '[': r = '\\left\\lbrack';
         break;
       case '{': r = '\\left\\lbrace';
         break;
@@ -45,13 +44,12 @@ const Brackets = {
     let r = '';
     switch(it){
       case ')':
+      case ']':
       case '|': r = `\\right${it}`;
         break;
       case '‖': r = '\\right\\|';
         break;
       case '}': r = '\\right\\rbrace';
-        break;
-      case ']': r = '\\right\\rbrack';
         break;
       case '⟩': r = ' \\right\\rangle';
         break;

--- a/src/brackets.js
+++ b/src/brackets.js
@@ -25,7 +25,7 @@ const Brackets = {
         break;
       case '‖': r = '\\left\\|';
         break;
-      case '{': r = '\\left\\{';
+      case '{': r = '\\left\\lbrace';
         break;
       case '⟨': r = '\\left\\langle ';
         break;
@@ -49,7 +49,7 @@ const Brackets = {
         break;
       case '‖': r = '\\right\\|';
         break;
-      case '}': r = '\\right\\}';
+      case '}': r = '\\right\\rbrace';
         break;
       case '⟩': r = ' \\right\\rangle';
         break;

--- a/src/math-symbol.js
+++ b/src/math-symbol.js
@@ -11,10 +11,14 @@ const MathSymbol = {
   parseIdentifier: function(it) {
     if(it.length === 0){ return '' }
     if(it.length === 1){
+      const symbols = {
+        decimals: [...this.greekLetter.decimals, ...this.other.decimals],
+        scripts: [...this.greekLetter.scripts, ...this.other.scripts],
+      } 
       const charCode = it.charCodeAt(0);
-      let index = this.greekLetter.decimals.indexOf(charCode)
+      let index = symbols.decimals.indexOf(charCode)
       if ( index > -1) {
-        return this.greekLetter.scripts[index] + ' ';
+        return symbols.scripts[index] + ' ';
       } else {
         return it;
       }

--- a/src/mathml2latex.js
+++ b/src/mathml2latex.js
@@ -148,7 +148,7 @@ function renderChildren(children) {
               lefts.push(op);
             }else{
               parts.push(Brackets.parseRight(op, stretchy));
-              rights.pop();
+              rights.push(op);
             }
           }
         } else {
@@ -162,7 +162,8 @@ function renderChildren(children) {
       parts.push(parse(node));
     }
   });
-  // 這裏非常不嚴謹
+
+  // add pending lefts brackets
   if(lefts.length > 0){
     for(let i=0; i < lefts.length; i++){
       parts.push("\\right.");
@@ -170,6 +171,7 @@ function renderChildren(children) {
   }
   lefts = undefined;
 
+  // add pending rights brackets
   if(rights.length > 0){
     for(let i=0; i < rights.length; i++){
       parts.unshift("\\left.");

--- a/src/mathml2latex.js
+++ b/src/mathml2latex.js
@@ -215,7 +215,7 @@ function getRender(node) {
       render = renderTable;
       break;
     case "mtr":
-      const siblings = [...children[0].parentElement.parentElement.children];
+      const siblings = Array.from(node.parentElement.children);
       const isLastSibling = siblings.indexOf(node) === siblings.length - 1;
       if (isLastSibling) {
         render = getRender_joinSeparator("@content ", " & ");

--- a/src/mathml2latex.js
+++ b/src/mathml2latex.js
@@ -28,9 +28,9 @@ function toLatex(result) {
 function parse(node) {
   const children = NodeTool.getChildren(node);
   if (!children || children.length === 0) {
-    return parseLeaf(node).trim();
+    return parseLeaf(node);
   } else {
-    return parseContainer(node, children).trim();
+    return parseContainer(node, children);
   }
 }
 
@@ -361,7 +361,7 @@ function renderMover(node, children){
       judgeChar: over,
       defaultValue: "\\overset{@2}{@1}"
     })
-    result = renderTemplate(template.replace("@v", "@1"), [result, over]);
+    result = renderTemplate(template.replace("@v", "@1"), [result.trim(), over.trim()]);
   }
   return result;
 }
@@ -378,7 +378,7 @@ function renderMunder(node, children){
       judgeChar: under,
       defaultValue: "\\underset{@2}{@1}"
     })
-    result =  renderTemplate(template.replace("@v", "@1"), [result, under]);
+    result =  renderTemplate(template.replace("@v", "@1"), [result.trim(), under.trim()]);
   }
   return result;
 }

--- a/src/mathml2latex.js
+++ b/src/mathml2latex.js
@@ -131,10 +131,9 @@ function renderChildren(children) {
     if(NodeTool.getNodeName(node) === 'mo'){
       const op = NodeTool.getNodeText(node).trim();
       if(Brackets.contains(op)){
-        debugger;
         let stretchy = NodeTool.getAttr(node, 'stretchy', 'true');
         stretchy = ['', 'true'].indexOf(stretchy) > -1;
-        // operators are b
+        // operators are brackets
         if(Brackets.isRight(op)){
           const nearLeft = lefts[lefts.length - 1];
           if(nearLeft){
@@ -348,11 +347,15 @@ function renderMover(node, children){
   for(let i = 0; i < nodes.length - 1; i++) {
     if(!result){ result = parse(nodes[i]) }
     const over = parse(nodes[i + 1]);
+    const templates = {
+      '^': "\\widehat{@1}",
+      '¯': "\\overline{@1}",
+    }
     const template = getMatchValueByChar({
       decimals: MathSymbol.overScript.decimals,
       values: MathSymbol.overScript.templates,
       judgeChar: over,
-      defaultValue: "\\overset{@2}{@1}"
+      defaultValue: templates?.[over] || "\\overset{@2}{@1}"
     })
     result = renderTemplate(template.replace("@v", "@1"), [result.trim(), over.trim()]);
   }

--- a/src/mathml2latex.js
+++ b/src/mathml2latex.js
@@ -214,8 +214,14 @@ function getRender(node) {
     case 'mtable':
       render = renderTable;
       break;
-    case 'mtr':
-      render = getRender_joinSeparator("@content \\\\ ", ' & ');
+    case "mtr":
+      const siblings = [...children[0].parentElement.parentElement.children];
+      const isLastSibling = siblings.indexOf(node) === siblings.length - 1;
+      if (isLastSibling) {
+        render = getRender_joinSeparator("@content ", " & ");
+      } else {
+        render = getRender_joinSeparator("@content \\\\ ", " & ");
+      }
       break;
     case 'mtd':
       render = getRender_joinSeparator("@content");

--- a/src/mathml2latex.js
+++ b/src/mathml2latex.js
@@ -127,35 +127,28 @@ function parseContainer(node, children) {
 function renderChildren(children) {
   const parts = [];
   let lefts = [];
+  let rights = [];
   Array.prototype.forEach.call(children, (node) => {
     if(NodeTool.getNodeName(node) === 'mo'){
       const op = NodeTool.getNodeText(node).trim();
       if(Brackets.contains(op)){
+        debugger;
         let stretchy = NodeTool.getAttr(node, 'stretchy', 'true');
         stretchy = ['', 'true'].indexOf(stretchy) > -1;
-        // 操作符是括號
+        // operators are b
         if(Brackets.isRight(op)){
           const nearLeft = lefts[lefts.length - 1];
           if(nearLeft){
-            if(Brackets.isPair(nearLeft, op)){
-              parts.push(Brackets.parseRight(op, stretchy));
-              lefts.pop();
-            } else {
-              // some brackets left side is same as right side.
-              if(Brackets.isLeft(op)) {
-                parts.push(Brackets.parseLeft(op, stretchy));
-                lefts.push(op);
-              } else {
-                console.error("bracket not match");
-              }
-            }
+            parts.push(Brackets.parseRight(op, stretchy));
+            lefts.pop();
           }else{
             // some brackets left side is same as right side.
             if(Brackets.isLeft(op)) {
               parts.push(Brackets.parseLeft(op, stretchy));
               lefts.push(op);
             }else{
-              console.error("bracket not match")
+              parts.push(Brackets.parseRight(op, stretchy));
+              rights.pop();
             }
           }
         } else {
@@ -176,6 +169,13 @@ function renderChildren(children) {
     }
   }
   lefts = undefined;
+
+  if(rights.length > 0){
+    for(let i=0; i < rights.length; i++){
+      parts.unshift("\\left.");
+    }
+  }
+  rights = undefined;
   return parts;
 }
 

--- a/src/mathml2latex.js
+++ b/src/mathml2latex.js
@@ -127,7 +127,6 @@ function parseContainer(node, children) {
 function renderChildren(children) {
   const parts = [];
   let lefts = [];
-  let rights = [];
   Array.prototype.forEach.call(children, (node) => {
     if(NodeTool.getNodeName(node) === 'mo'){
       const op = NodeTool.getNodeText(node).trim();
@@ -147,8 +146,7 @@ function renderChildren(children) {
               parts.push(Brackets.parseLeft(op, stretchy));
               lefts.push(op);
             }else{
-              parts.push(Brackets.parseRight(op, stretchy));
-              rights.push(op);
+              parts.push(op);
             }
           }
         } else {
@@ -171,13 +169,6 @@ function renderChildren(children) {
   }
   lefts = undefined;
 
-  // add pending rights brackets
-  if(rights.length > 0){
-    for(let i=0; i < rights.length; i++){
-      parts.unshift("\\left.");
-    }
-  }
-  rights = undefined;
   return parts;
 }
 

--- a/src/mathml2latex.js
+++ b/src/mathml2latex.js
@@ -28,9 +28,9 @@ function toLatex(result) {
 function parse(node) {
   const children = NodeTool.getChildren(node);
   if (!children || children.length === 0) {
-    return parseLeaf(node);
+    return parseLeaf(node).trim();
   } else {
-    return parseContainer(node, children);
+    return parseContainer(node, children).trim();
   }
 }
 
@@ -370,7 +370,7 @@ function renderMunder(node, children){
       decimals: MathSymbol.underScript.decimals,
       values: MathSymbol.underScript.templates,
       judgeChar: under,
-      defaultValue: "@1\\limits_{@2}"
+      defaultValue: "\\underset{@2}{@1}"
     })
     result =  renderTemplate(template.replace("@v", "@1"), [result, under]);
   }

--- a/src/mathml2latex.js
+++ b/src/mathml2latex.js
@@ -359,7 +359,7 @@ function renderMover(node, children){
       decimals: MathSymbol.overScript.decimals,
       values: MathSymbol.overScript.templates,
       judgeChar: over,
-      defaultValue: "@1\\limits^{@2}"
+      defaultValue: "\\overset{@2}{@1}"
     })
     result = renderTemplate(template.replace("@v", "@1"), [result, over]);
   }

--- a/src/mathml2latex.js
+++ b/src/mathml2latex.js
@@ -54,7 +54,7 @@ function parseLeaf(node) {
     case 'mprescripts': r = '';
       break;
     case 'mspace': r = parseElementMspace(node);
-    case 'none': r = '\\:';
+    case 'none': r = '\\;';
     //TODO other usecase of 'none' ?
       break;
     default: r = escapeSpecialChars(NodeTool.getNodeText(node).trim());


### PR DESCRIPTION
I have modified the `mtr` parse to detect when it is the last element of the matrix and prevent adding the extra `\\` at the end.

For this Mathml input:

```xml
<math xmlns="http://www.w3.org/1998/Math/MathML">
  <mtable columnspacing="1em" rowspacing="4pt">
    <mtr>
      <mtd>
        <mi>a</mi>
      </mtd>
    </mtr>
    <mtr>
      <mtd>
        <mi>b</mi>
      </mtd>
    </mtr>
  </mtable>
</math>
```

Currently we received this latex output:
```latex
\begin{matrix} a \\ b \\  \end{matrix}
```

After the changes the result is as follows:
```latex
\begin{matrix} a \\ b  \end{matrix}
```

___

Additionally, I fixed the conversion of `munder` and  `mover` to use `\underset` and `\overset` instead of `\limits`. (this fixes this issue https://github.com/mika-cn/mathml2latex/issues/9)

I also added the symbols of the "other" category to the parseIdentifier function, since they can be used as identifiers.